### PR TITLE
Better copy button to the code block

### DIFF
--- a/assets/index.css
+++ b/assets/index.css
@@ -316,3 +316,42 @@ svg.lucide {
         transition: transform var(--transition-fast) ease-out;
     }
 }
+/* Code block copy button */
+.code-block-wrapper {
+    position: relative;
+}
+
+.copy-code-button {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: grid;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    color: var(--neutral-600);
+    background: var(--neutral-100);
+    border: 1px solid var(--neutral-200);
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s;
+    z-index: 1;
+}
+
+.copy-code-button:hover,
+.copy-code-button:focus-visible {
+    color: var(--neutral-700);
+    background: var(--neutral-200);
+}
+
+.copy-code-button svg.lucide {
+    width: 14px;
+    height: 14px;
+}
+
+.code-block-wrapper:hover .copy-code-button,
+.copy-code-button:focus-visible {
+    opacity: 1;
+}

--- a/commons/utils/renderMarkdown.js
+++ b/commons/utils/renderMarkdown.js
@@ -32,5 +32,20 @@ export default function renderMarkdown(text) {
     return defaultRender(tokens, idx, options, env, self);
   };
 
+  const defaultFence = md.renderer.rules.fence || function (tokens, idx, options, env, self) {
+    return self.renderToken(tokens, idx, options);
+  };
+  md.renderer.rules.fence = function (tokens, idx, options, env, self) {
+    const original = defaultFence(tokens, idx, options, env, self);
+    return `
+<div class="code-block-wrapper">
+  <button type="button" class="copy-code-button" onclick="window.copyCode(this)" aria-label="Copy code" title="Copy code">
+    ${window.copyCodeIcon}
+  </button>
+  ${original}
+</div>
+`;
+  };
+
   return md.render(text);
 }

--- a/index.js
+++ b/index.js
@@ -15,6 +15,61 @@ import Tooltip from './commons/components/Tooltip.js';
 import { AppProvider } from './commons/contexts/AppContext.jsx';
 import ThemePreferences from './commons/preferences/ThemePreferences.js';
 
+
+const copyCodeIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-copy"><rect width="14" height="14" x="8" y="8" rx="2" ry="2" /><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" /></svg>';
+const checkCodeIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check"><path d="M20 6 9 17l-5-5" /></svg>';
+
+function copyCode(button) {
+  const wrapper = button.closest('.code-block-wrapper');
+  if (!wrapper) return;
+  const pre = wrapper.querySelector('pre');
+  if (!pre) return;
+  const code = pre.innerText;
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(code).then(() => {
+      showCopied(button);
+    }).catch(err => {
+      console.error('Failed to copy: ', err);
+      fallbackCopyTextToClipboard(code, button);
+    });
+    return;
+  }
+  fallbackCopyTextToClipboard(code, button);
+}
+
+function fallbackCopyTextToClipboard(text, button) {
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.style.position = 'fixed';
+  textArea.style.top = '-9999px';
+  textArea.style.left = '-9999px';
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  try {
+    if (document.execCommand('copy')) {
+      showCopied(button);
+    } else {
+      console.error('Fallback copy failed');
+    }
+  } catch (err) {
+    console.error('Fallback copy error: ', err);
+  }
+  document.body.removeChild(textArea);
+}
+
+function showCopied(button) {
+  button.innerHTML = checkCodeIcon;
+  button.setAttribute('aria-label', 'Copied');
+  button.setAttribute('title', 'Copied');
+  setTimeout(() => {
+    button.innerHTML = copyCodeIcon;
+    button.setAttribute('aria-label', 'Copy code');
+    button.setAttribute('title', 'Copy code');
+  }, 2000);
+}
+window.copyCode = copyCode;
+window.copyCodeIcon = copyCodeIcon;
 document.addEventListener('DOMContentLoaded', () => {
   ThemePreferences.applyTheme();
   Tooltip.init();


### PR DESCRIPTION
It’s similar to #6  but better.

<img width="793" height="152" alt="image" src="https://github.com/user-attachments/assets/08ac3751-fae6-4b58-b842-a6044caea3b8" />